### PR TITLE
Feature/protecting routes

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -33,6 +33,7 @@ module.exports = {
             sidebarDepth: 1,    // optional, defaults to 1
             children: [
               '/api/installation',
+              '/api/upgrading',
               '/api/configuration',
               '/api/order-lifecycle'
             ]

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -34,6 +34,7 @@ module.exports = {
             children: [
               '/api/installation',
               '/api/upgrading',
+              '/api/protecting-routes',
               '/api/configuration',
               '/api/order-lifecycle'
             ]

--- a/docs/api/installation.md
+++ b/docs/api/installation.md
@@ -23,13 +23,13 @@ The GetCandy API is a Laravel package, designed to be easily added to any new or
 Require the API package (currently in Beta)
 
 ```
-composer require getcandy/candy-api:dev-release/0.9.0_beta
+composer require getcandy/candy-api:^0.9-beta
 ```
 
 Or add this to your `composer.json` file
 
 ```javascript
-"getcandy/candy-api": "dev-release/0.9.0_beta"
+"getcandy/candy-api": "^0.9-beta"
 ```
 
 ### A note on Vimeo uploads
@@ -69,21 +69,6 @@ class User extends Authenticatable
 //...
 ```
 
-Update your authentication config to enable passport
-
-`config/auth.php`
-
-```php
-'guards' => [
-    //...
-    'api' => [
-        'driver' => 'passport',
-        'provider' => 'users',
-        'hash' => false,
-    ],
-]
-```
-
 ## Enable GetCandy routes
 
 Update your `RouteServiceProvider` and add the GetCandy routes.
@@ -104,16 +89,14 @@ public function map()
 }
 ```
 
+::: danger
+GetCandy no longer ships with Passport so you will need to protect your routes. See [Protecting your routes](/api/protecting-routes)
+:::
+
 ## Run the installer
 
 ```
 php artisan candy:install
-```
-
-Install Laravel Passport
-
-```
-php artisan passport:install
 ```
 
 Lastly we need to create an initial index in Elasticsearch, we don't have any products yet, which is fine, we just need to get it going.

--- a/docs/api/protecting-routes.md
+++ b/docs/api/protecting-routes.md
@@ -1,0 +1,87 @@
+---
+title: Protecting routes
+description: Guidance on how you can protect your API routes in GetCandy
+---
+
+# Protecting routes
+
+[[toc]]
+
+GetCandy tries not to make any assumptions on how you protect your API routes, all it cares about is whether there is an authenticated user. So whether you decide to use JWT, Sanctum or Passport, it shouldn't get in your way.
+
+We've added some guides for how you might implement this across different providers. If you feel you can improve these guides, please submit a PR to [Guides repository](https://github.com/getcandy/guides) and we'll take a look.
+
+Before we start, it makes sense to get an idea of the different route groups that GetCandy uses.
+
+```php
+use GetCandy
+//...
+GetCandy::routes(function ($registrar) {
+    $registrar->auth();
+    $registrar->guest();
+})
+```
+
+**Guest routes**  
+These are routes which may or may not have an authenticated user associated to the request.
+
+**Auth routes**  
+These routes must have an authenticated user associated to the request and will include routes that require an admin.
+
+## Sanctum
+
+As described on the [Laravel website](https://laravel.com/docs/7.x/sanctum)
+
+> Laravel Sanctum provides a featherweight authentication system for SPAs (single page applications), mobile applications, and simple, token based APIs
+
+Install Sanctum as [per their documentation]((https://laravel.com/docs/7.x/sanctum)).
+
+For the `auth` routes we want to add the sanctum middleware, we do not need to add any middleware to the guest routes as we'll be handling this through CORs and some Sanctum config.
+
+```php
+use GetCandy
+use Illuminate\Support\Facades\Route;
+//...
+GetCandy::routes(function ($registrar) {
+    Route::group([
+        'middleware' => 'auth:sanctum'
+    ], function () use ($registrar) {
+        $registrar->auth();
+    })
+    $registrar->guest();
+})
+```
+
+Once you have authenticated a user, they will still appear for guest routes on `$request->user()`.
+
+## Passport
+
+GetCandy originall was built with Passport integrated into the core. [From the Laravel website](https://laravel.com/docs/7.x/passport)
+
+>  Laravel makes API authentication a breeze using Laravel Passport, which provides a full OAuth2 server implementation for your Laravel application in a matter of minutes.
+
+Install Passport as per their documentation.
+
+```php
+use GetCandy
+use Illuminate\Support\Facades\Route;
+//...
+GetCandy::routes(function ($registrar) {
+    Route::group([
+        'middleware' => 'auth:api'
+    ], function () use ($registrar) {
+        $registrar->auth();
+    })
+    $registrar->guest();
+})
+```
+
+### Guest routes and client credentials
+Previously, GetCandy used an altered version of the `Laravel\Passport\Http\Middleware\CheckClientCredentials` middleware, but since removing Passport from the core, we found this would have been too opinionated.
+
+The issue with the original middleware was this allowed access tokens created via the `client_credentials` grant to access the API, but also meant that even if a user with an authenticated access token pinged the API, they wouldn't be bound to the request.
+
+There seems to be some debate on this, [which you can see here](https://github.com/laravel/passport/issues/898), we currently do not have a solution that wouldn't require opinionated changes to the core GetCandy middleware, so for now we suggest reading the thread linked above and make a concious decision based on your own needs.
+
+If we figure out a solid solution we will post it either here or in the [forum](https://community.getcandy.io/) for discussion.
+

--- a/docs/api/upgrading.md
+++ b/docs/api/upgrading.md
@@ -1,0 +1,30 @@
+---
+title: Upgrading
+description: Upgrading GetCandy
+extends: _layouts.documentation
+section: content
+---
+
+
+# Upgrading
+
+[[toc]]
+
+## Upgrading to Beta from 0.3
+
+Update `getcandy/candy-api` to `0.9.*-beta` in your composer file.
+
+
+Run composer update and migrations
+```
+composer update getcandy/candy-api
+php artisan migrate
+```
+
+## High impact changes
+
+### Passport removal
+
+GetCandy will no longer ship with Laravel Passport. We felt that, given there are multiple ways to authenticate, the API shouldn't be concerned with how you do this, only that we have a user on those routes that require it.
+
+We highly recommend you do protect your API, we have provided guides on how we think it can be done, but it is entirely up to you how you do it.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {},
   "scripts": {
-    "docs:dev": "vuepress dev docs",
+    "dev": "vuepress dev docs",
     "docs:build": "vuepress build docs"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds guides on how to protect your GetCandy API.

https://deploy-preview-1--getcandy-guides.netlify.app/api/protecting-routes